### PR TITLE
feat: serve cotovia via ovos-tts-server docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+test
+**/__pycache__
+*.py[cod]
+.pytest_cache
+*.egg-info
+.venv
+TODO.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: docker
+
+on:
+  push:
+    branches: [master, dev]
+    tags: ["*.*.*", "V*", "v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=ref,event=tag
+            type=sha,format=short
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Cotovia Galician/Spanish unit-selection TTS served through ovos-tts-server's
+# ElevenLabs-compatible API. A self-contained, offline image: any client that speaks
+# the ovos-tts-server / ElevenLabs API can hit it, and it can be A/B-tested against
+# other ovos-tts-server voices by pointing at a different port.
+#
+# The cotovia synthesis binary ships inside the plugin wheel (bin/cotovia_<arch>), but
+# get_tts also needs the Galician linguistic data and at least one voice under
+# /usr/share/cotovia/data. Those are distributed as .deb packages on SourceForge (not
+# in the Ubuntu/Debian apt repos), so they are downloaded and installed at build time.
+# The image build therefore needs network access to SourceForge.
+FROM python:3.11-slim
+
+# curl to fetch the .deb packages; installing the cotovia .deb also pulls the binary's
+# shared-library dependencies (libexpat1, libasound2, libstdc++6, ...).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cotovia executable + Galician linguistic data + the "iago" voice (the config default).
+# The voice/lang data lands in /usr/share/cotovia/data, which the plugin reads.
+# `apt-get install ./*.deb` resolves the debs' own dependencies from the apt repos.
+RUN apt-get update \
+    && base="https://sourceforge.net/projects/cotovia/files/Debian%20packages" \
+    && for pkg in cotovia_0.5_amd64.deb cotovia-lang-gl_0.5_all.deb cotovia-voice-iago_0.5_all.deb; do \
+         curl -fSL --retry 5 --retry-delay 5 -o "/tmp/$pkg" "$base/$pkg/download"; \
+       done \
+    && apt-get install -y --no-install-recommends \
+         /tmp/cotovia_0.5_amd64.deb \
+         /tmp/cotovia-lang-gl_0.5_all.deb \
+         /tmp/cotovia-voice-iago_0.5_all.deb \
+    && rm -f /tmp/*.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && ls /usr/share/cotovia/data
+
+WORKDIR /app
+COPY . /app
+
+# the plugin + the OVOS TTS server. setuptools<81 keeps ovos-plugin-manager's
+# pkg_resources usage working. cotovia emits WAV natively, so no ffmpeg transcode is
+# needed; the alpha floor lets pip resolve the prerelease without --pre.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir "setuptools<81" "." "ovos-tts-server>=1.13.5a1"
+
+# Served voice/lang, overridable with the COTOVIA_VOICE / COTOVIA_LANG build args.
+# iago is the only voice installed above; add other voice .debs to serve them.
+ARG COTOVIA_VOICE=iago
+ARG COTOVIA_LANG=gl-es
+RUN useradd -m -u 1000 ovos \
+    && mkdir -p /home/ovos/.config/mycroft \
+    && printf '{\n  "lang": "%s",\n  "tts": {\n    "module": "ovos-tts-plugin-cotovia",\n    "ovos-tts-plugin-cotovia": {\n      "lang": "%s",\n      "voice": "%s"\n    }\n  }\n}\n' "${COTOVIA_LANG}" "${COTOVIA_LANG}" "${COTOVIA_VOICE}" \
+        > /home/ovos/.config/mycroft/mycroft.conf \
+    && chown -R 1000:1000 /home/ovos/.config
+USER 1000
+
+EXPOSE 9666
+ENTRYPOINT ["ovos-tts-server", "--engine", "ovos-tts-plugin-cotovia", \
+            "--host", "0.0.0.0", "--port", "9666", "--cache"]

--- a/README.md
+++ b/README.md
@@ -101,3 +101,20 @@ Additional configuration params are available
 ```
 
 
+## Docker (ovos-tts-server)
+
+A container image runs the plugin as an
+[`ovos-tts-server`](https://github.com/OpenVoiceOS/ovos-tts-server) (ElevenLabs-compatible
+API), built and pushed to GHCR by CI on every push to `dev`/`master`:
+
+```bash
+docker run -p 9666:9666 ghcr.io/openvoiceos/ovos-tts-plugin-cotovia:latest
+curl "http://localhost:9666/synthesize/ola%20mundo?lang=gl" --output ola.wav
+```
+
+The image bundles the cotovia binary (from the wheel) and downloads the Galician
+linguistic data plus the `iago` voice from SourceForge at build time (into
+`/usr/share/cotovia/data`), so the running container is fully offline. The served
+voice/lang are baked in via the `COTOVIA_VOICE` (default `iago`) and `COTOVIA_LANG`
+(default `gl-es`) build args; add other voice `.deb` packages to the Dockerfile and
+rebuild to serve `sabela`. See the bundled `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  cotovia-tts:
+    image: ghcr.io/openvoiceos/ovos-tts-plugin-cotovia:latest
+    # …or build locally: build: .
+    container_name: cotovia-tts
+    restart: unless-stopped
+    ports:
+      - "9666:9666"
+    # optional: override the served voice/lang (build args; rebuild to change)
+    # build:
+    #   context: .
+    #   args:
+    #     COTOVIA_VOICE: iago
+    #     COTOVIA_LANG: gl-es
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9666/status')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
Adds a container that runs the plugin behind `ovos-tts-server` (ElevenLabs-compatible API) on port 9666, published to `ghcr.io/openvoiceos/ovos-tts-plugin-cotovia` by CI.

## Files
- `Dockerfile` — `python:3.11-slim`; installs the plugin + `ovos-tts-server`. The cotovia synthesis binary ships in the wheel (`bin/cotovia_<arch>`), but `get_tts` also needs the Galician linguistic data and a voice under `/usr/share/cotovia/data`. Those are distributed only as `.deb` packages on SourceForge, so the build downloads and installs `cotovia_0.5_amd64.deb`, `cotovia-lang-gl_0.5_all.deb` and `cotovia-voice-iago_0.5_all.deb`. Once built, the container is fully offline.
- `docker-compose.yml` — one-service compose with a `/status` healthcheck.
- `.github/workflows/docker.yml` — build on PR, build+push to GHCR on `dev`/`master`/tags.
- `.dockerignore` + README "Docker" section.

## Notes
- Default served voice `iago`, default lang `gl-es`; overridable via `COTOVIA_VOICE` / `COTOVIA_LANG` build args. `sabela` needs its (large) voice `.deb` added to the Dockerfile.
- cotovia emits WAV natively, so no ffmpeg transcode is needed.
- Build-time caveat: the voice/lang data is fetched from SourceForge at build time (~155 MB), so the image build depends on SourceForge availability.