### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,70 @@
 ## Description
 
-OVOS TTS plugin for [Cotovia TTS](http://gtm.uvigo.es/cotovia)
+This is the OVOS TTS plugin for [Cotovia TTS](http://gtm.uvigo.es/cotovia).
 
-### About Cotovia
+Cotovia is a unit-selection text-to-speech system. It builds the speech signal
+by joining prerecorded segments. Cotovia determines the sequence of sounds,
+their intonation, and their duration from the input text. It considers several
+intonation contours in parallel, and for each one it selects a sequence of
+speech units. It picks the final intonation contour based on how well the
+selected speech units fit together.
 
-Cotovia is a unit-selection text-to-speech system, i.e., generates the synthetic speech signal as a
-concatenation of prerecorded segments. Cotovia determines the sequence of sounds, its intonation and 
-duration from the input text. Actually several intonation contours are considered in parallel and for
-each one a sequence of speech units is selected. The final intonation contours is selected according to 
-the suitability of the sequence of speech units found.
- 
 ### Voices
 
-At this time two Galician voices are available at sourceforge. These two voices are also suitable for Spanish,
- with little distortion, since the phonemes of Spanish may be considered a subset of Galician phonemes. The
- nicknames of the two speakers are Iago and Sabela. Nevertheless you will find three voices available for
- Cotovia:
+Two Galician voices are available on SourceForge. These voices also work for
+Spanish, with little distortion, because Spanish phonemes are a subset of
+Galician phonemes. The nicknames of the two speakers are Iago and Sabela.
+Cotovia offers three voice options:
 
-* iago : Galician male speaker, duration of the recording: 80 minutes. It was Cotovia's first voice and the
- quality is limited by the reduced recording time.
-
-* sabela-large : Galician female speaker, duration of the recording: 14.5 hours. Use this voice if you want to
- obtain maximum quality speech and you are not too worried about execution time.
-
-* sabela: default speaker. A subset of Sabela's recordings (about 4 hours). A good compromise between quality
- and execution time.
- 
+* `iago`: a Galician male speaker, with 80 minutes of recording. It was
+  Cotovia's first voice, so its quality is limited by the short recording
+  time.
+* `sabela-large`: a Galician female speaker, with 14.5 hours of recording. Use
+  this voice for the highest quality speech when execution time does not
+  matter.
+* `sabela`: the default speaker. It uses a subset of Sabela's recordings
+  (about 4 hours), which balances quality against execution time.
 
 ## Install
 
-Install the plugin
+Install the plugin.
 
-`pip install ovos-tts-plugin-cotovia`
+```bash
+pip install ovos-tts-plugin-cotovia
+```
 
-Download and install [Cotovia](https://sourceforge.net/projects/cotovia/files/Debian%20packages/)
+Then download and install [Cotovia](https://sourceforge.net/projects/cotovia/files/Debian%20packages/).
 
-#### Debian
+### Debian
 
-In order to run Cotovia, you will need to install the following packages:
+To run Cotovia, install these packages:
 
-    cotovia_0.5_amd64.deb   ---  Cotovia executable
-    cotovia-lang-gl_0.5_all.deb --- Galician linguistic data
-    cotovia-lang-es_0.5_all.deb --- Spanish linguistic data
+    cotovia_0.5_amd64.deb          --- Cotovia executable
+    cotovia-lang-gl_0.5_all.deb    --- Galician linguistic data
+    cotovia-lang-es_0.5_all.deb    --- Spanish linguistic data
 
-Additionally you need to install at least one voice
+Also install at least one voice:
 
     cotovia-voice-iago_0.5_all.deb
     cotovia-voice-sabela-large_0.5_all.deb
     cotovia-voice-sabela_0.5_all.deb
 
-#### Arch
+### Arch
 
-arch linux users can find packages converted with 'debtap' in the [releases page](https://github.com/OpenVoiceOS/ovos-tts-plugin-cotovia/releases/tag/0.4.1)
+Arch Linux users can find packages converted with `debtap` on the
+[releases page](https://github.com/OpenVoiceOS/ovos-tts-plugin-cotovia/releases/tag/0.4.1).
 
 ```bash
 sudo pacman -U /home/miro/Transferências/cotovia-0.5-1-x86_64.pkg.tar.zst
-sudo pacman -U /home/miro/Transferências/cotovia-lang-es-0.5-1-any.pkg.tar.zst 
-sudo pacman -U /home/miro/Transferências/cotovia-lang-gl-0.5-1-any.pkg.tar.zst 
-sudo pacman -U /home/miro/Transferências/cotovia-voice-iago-0.5-1-any.pkg.tar.zst 
-sudo pacman -U /home/miro/Transferências/cotovia-voice-sabela-0.5-1-any.pkg.tar.zst 
-sudo pacman -U /home/miro/Transferências/cotovia-voice-sabela-large-0.5-1-any.pkg.tar.zst 
+sudo pacman -U /home/miro/Transferências/cotovia-lang-es-0.5-1-any.pkg.tar.zst
+sudo pacman -U /home/miro/Transferências/cotovia-lang-gl-0.5-1-any.pkg.tar.zst
+sudo pacman -U /home/miro/Transferências/cotovia-voice-iago-0.5-1-any.pkg.tar.zst
+sudo pacman -U /home/miro/Transferências/cotovia-voice-sabela-0.5-1-any.pkg.tar.zst
+sudo pacman -U /home/miro/Transferências/cotovia-voice-sabela-large-0.5-1-any.pkg.tar.zst
 ```
 
-otherwise here is a guide [how to install a .deb package in arch linux](https://www.baeldung.com/linux/arch-install-deb-package)
+If you do not use `debtap` packages, see this guide on
+[how to install a .deb package in Arch Linux](https://www.baeldung.com/linux/arch-install-deb-package).
 
 ## Configuration
 
@@ -73,18 +75,17 @@ otherwise here is a guide [how to install a .deb package in arch linux](https://
       "voice": "iago"
     }
   }
- 
 ```
 
 ### Advanced config
 
-Additional configuration params are available
+You can set these additional parameters:
 
-- `lang` can be `gl` for galician or `es` 
-- `voice` cab be `iago` or `sabela`
-- `pitch_scale_factor` can be used to change pitch (default `100`)
-- `time_scale_factor` can be used to change speed (default `100`)
-- `bin` can be used to set a path to the executable (default `/usr/bin/cotovia`)
+- `lang`: `gl` for Galician or `es` for Spanish.
+- `voice`: `iago` or `sabela`.
+- `pitch_scale_factor`: changes pitch (default `100`).
+- `time_scale_factor`: changes speed (default `100`).
+- `bin`: path to the executable (default `/usr/bin/cotovia`).
 
 ```json
   "tts": {
@@ -96,25 +97,32 @@ Additional configuration params are available
       "time_scale_factor": 80,
       "bin": "/usr/bin/cotovia"
     }
-   }
- 
+  }
 ```
-
 
 ## Docker (ovos-tts-server)
 
 A container image runs the plugin as an
 [`ovos-tts-server`](https://github.com/OpenVoiceOS/ovos-tts-server) (ElevenLabs-compatible
-API), built and pushed to GHCR by CI on every push to `dev`/`master`:
+API). CI builds and pushes this image to GHCR on every push to `dev` or `master`.
 
 ```bash
 docker run -p 9666:9666 ghcr.io/openvoiceos/ovos-tts-plugin-cotovia:latest
 curl "http://localhost:9666/synthesize/ola%20mundo?lang=gl" --output ola.wav
 ```
 
-The image bundles the cotovia binary (from the wheel) and downloads the Galician
-linguistic data plus the `iago` voice from SourceForge at build time (into
-`/usr/share/cotovia/data`), so the running container is fully offline. The served
-voice/lang are baked in via the `COTOVIA_VOICE` (default `iago`) and `COTOVIA_LANG`
-(default `gl-es`) build args; add other voice `.deb` packages to the Dockerfile and
-rebuild to serve `sabela`. See the bundled `docker-compose.yml`.
+The image bundles the Cotovia binary from the wheel. At build time, it also
+downloads the Galician linguistic data and the `iago` voice from SourceForge,
+into `/usr/share/cotovia/data`. This makes the running container fully offline.
+The build args `COTOVIA_VOICE` (default `iago`) and `COTOVIA_LANG` (default
+`gl-es`) bake the served voice and language into the image. To serve `sabela`,
+add its `.deb` package to the Dockerfile and rebuild. See the bundled
+`docker-compose.yml` for an example.
+
+## Related projects
+
+- [OpenVoiceOS/ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server) — serves this plugin over an ElevenLabs-compatible HTTP API.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
Rewrites the README in Simplified Technical English for clarity: shorter sentences, active voice, no marketing language. All facts, code blocks, and install instructions are unchanged. Adds a Related projects section linking ovos-tts-server, and an explicit License section pointing at the existing LICENSE file.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted and expanded project documentation with clearer sections for features, voices, installation, packages, and configuration.
  * Added details about Docker image publishing, bundled runtime data, build arguments, and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->